### PR TITLE
Minor fixes: R version and .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+.github
+LICENSE.md
+codecov.yml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Biarch: true
 Depends: 
-    R (>= 3.4.0)
+    R (>= 3.5.0)
 Imports: 
     methods,
     purrr,
@@ -35,7 +35,6 @@ LinkingTo:
 SystemRequirements: GNU make
 Suggests: 
     knitr,
-    purrr,
     dplyr,
     rmarkdown,
     testthat (>= 3.0.0),


### PR DESCRIPTION
- some packages require R 3.5, so bumping up minimum base R version to match
- exclude some files from package build
- delicate mention of purrr in DESCRIPTION