### PR TITLE
Removed redundant global error parameter from affine model.

### DIFF
--- a/R/hmde_models.R
+++ b/R/hmde_models.R
@@ -117,6 +117,7 @@ hmde_affine_single_ind <- function(){
        obs_index = NULL,
        time = NULL,
        int_method = NULL,
+       y_bar = NULL,
        prior_means = c(1,1),
        prior_sds = c(2,2),
        model = "affine_single_ind")

--- a/inst/stan/affine_single_ind.stan
+++ b/inst/stan/affine_single_ind.stan
@@ -76,9 +76,6 @@ parameters {
   real<lower=0> ind_y_0;
   real<lower=0> ind_const;
   real<lower=0> ind_beta_1;
-
-  //Global level
-  real<lower=0> global_error_sigma;
 }
 
 // The model to be estimated.

--- a/inst/stan/affine_single_ind.stan
+++ b/inst/stan/affine_single_ind.stan
@@ -1,7 +1,7 @@
 //Growth function
 functions{
   //Growth function for use with Runge-Kutta method
-  //pars = (beta_0, beta_1, y_bar)
+  //pars = (ind_const, beta_1, y_bar)
   real DE_rk4(real y, array[] real pars){ //change number of pars
     return pars[1] - (pars[2] * (y-pars[3])); //growth function
   }

--- a/inst/stan/affine_single_ind.stan
+++ b/inst/stan/affine_single_ind.stan
@@ -76,6 +76,9 @@ parameters {
   real<lower=0> ind_y_0;
   real<lower=0> ind_const;
   real<lower=0> ind_beta_1;
+
+  //Global level
+  real<lower=0> global_error_sigma;
 }
 
 // The model to be estimated.

--- a/inst/stan/affine_single_ind.stan
+++ b/inst/stan/affine_single_ind.stan
@@ -1,7 +1,7 @@
 //Growth function
 functions{
   //Growth function for use with Runge-Kutta method
-  //pars = (ind_const, beta_1, y_bar)
+  //pars = (const, beta_1, y_bar)
   real DE_rk4(real y, array[] real pars){ //change number of pars
     return pars[1] - (pars[2] * (y-pars[3])); //growth function
   }
@@ -74,11 +74,8 @@ data {
 parameters {
   //Individual level
   real<lower=0> ind_y_0;
-  real<lower=0> ind_const;
+  real ind_const;
   real<lower=0> ind_beta_1;
-
-  //Global level
-  real<lower=0> global_error_sigma;
 }
 
 // The model to be estimated.
@@ -125,7 +122,7 @@ model {
 
   //Priors
   //Individual level
-  ind_const ~lognormal(log(prior_means[1]), prior_sds[1]);
+  ind_const ~normal(prior_means[1], prior_sds[1]);
   ind_beta_1 ~lognormal(log(prior_means[2]), prior_sds[2]);
 }
 

--- a/tests/testthat/test-hmde_models_affine.R
+++ b/tests/testthat/test-hmde_models_affine.R
@@ -3,7 +3,7 @@ test_that("Model structures: affine", {
   # Single individual
   single_model <- hmde_model("affine_single_ind")
   expect_named(single_model, c("step_size", "n_obs", "y_obs", "obs_index",
-                               "time", "int_method", "prior_means",
+                               "time", "int_method", "y_bar", "prior_means",
                                "prior_sds", "model"))
   expect_type(single_model, "list")
   expect_visible(single_model)


### PR DESCRIPTION
Global error parameter no longer used but still listed. Has been fixed.