### PR TITLE
Changed extract_estimates argument order so the output from run() can…

### DIFF
--- a/R/hmde_extract_estimates.R
+++ b/R/hmde_extract_estimates.R
@@ -9,8 +9,8 @@
 #' @import dplyr
 #' @importFrom stats quantile
 
-hmde_extract_estimates <- function(model = NULL,
-                                   fit = NULL,
+hmde_extract_estimates <- function(fit = NULL,
+                                   model = NULL,
                                    input_measurement_data = NULL){
   #Check for fit
   if(is.null(fit)){

--- a/tests/testthat/test-hmde_extract_estimates.R
+++ b/tests/testthat/test-hmde_extract_estimates.R
@@ -7,15 +7,13 @@ test_that("Execution and output: extract_estimates function", {
   )
 
   suppressWarnings(
-    constant_single_fit <- hmde_model("constant_single_ind") |>
+    output <- hmde_model("constant_single_ind") |>
       hmde_assign_data(data = data) |>
       hmde_run(chains = 1, iter = 20, cores = 1,
-               verbose = FALSE, show_messages = FALSE)
+               verbose = FALSE, show_messages = FALSE) |>
+      hmde_extract_estimates(model = "constant_single_ind",
+                             input_measurement_data = data)
   )
-
-  output <- hmde_extract_estimates(model = "constant_single_ind",
-                                   fit = constant_single_fit,
-                                   input_measurement_data = data)
 
   expect_named(output)
 


### PR DESCRIPTION
… be piped into the first arg as a fit.

Also updated testing for the function to reflect this structure.

While it's not strictly optimal to do because this workflow doesn't save the fit for diagnostics it is useful.